### PR TITLE
Fix DDG images results selector

### DIFF
--- a/data-raw/selectors.R
+++ b/data-raw/selectors.R
@@ -39,7 +39,7 @@ duckduckgo_text = list(
 
 ## duckduckgo images ----
 duckduckgo_images = list(
-    results   = c("div.tile","xml"),
+    results   = c("div.tile--img:not(.is-hidden)","xml"),
     title     = c("span.tile--img__title","text"),
     link      = c("a.tile--img__sub","link"),
     image     = c("img.tile--img__img","src")


### PR DESCRIPTION
Unfortunately, this more complicated result selector is needed because DuckDuckGo places a "hidden" image at the end of the image results for whatever reason.